### PR TITLE
DL-4058 - Create a new ActionBuilder to check if a claim has already been submitted

### DIFF
--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -26,6 +26,7 @@ class Module extends AbstractModule {
 
     bind(classOf[DataRetrievalAction]).to(classOf[DataRetrievalActionImpl]).asEagerSingleton()
     bind(classOf[DataRequiredAction]).to(classOf[DataRequiredActionImpl]).asEagerSingleton()
+    bind(classOf[CheckAlreadyClaimedAction]).to(classOf[CheckAlreadyClaimedActionImpl]).asEagerSingleton()
 
     // For session based storage instead of cred based, change to SessionIdentifierAction
     bind(classOf[IdentifierAction]).to(classOf[AuthenticatedIdentifierAction]).asEagerSingleton()

--- a/app/controllers/CannotClaimUsingThisServiceController.scala
+++ b/app/controllers/CannotClaimUsingThisServiceController.scala
@@ -28,13 +28,14 @@ import scala.concurrent.ExecutionContext
 class CannotClaimUsingThisServiceController @Inject()(
                                        override val messagesApi: MessagesApi,
                                        identify: IdentifierAction,
+                                       checkAlreadyClaimed: CheckAlreadyClaimedAction,
                                        getData: DataRetrievalAction,
                                        requireData: DataRequiredAction,
                                        val controllerComponents: MessagesControllerComponents,
                                        view: CannotClaimUsingThisServiceView
                                      )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
-  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) {
+  def onPageLoad: Action[AnyContent] = (identify andThen checkAlreadyClaimed andThen getData andThen requireData) {
     implicit request =>
       Ok(view())
   }

--- a/app/controllers/ConfirmationController.scala
+++ b/app/controllers/ConfirmationController.scala
@@ -32,6 +32,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class ConfirmationController @Inject()(
                                        override val messagesApi: MessagesApi,
                                        identify: IdentifierAction,
+                                       checkAlreadyClaimed: CheckAlreadyClaimedAction,
                                        getData: DataRetrievalAction,
                                        requireData: DataRequiredAction,
                                        val controllerComponents: MessagesControllerComponents,
@@ -39,7 +40,7 @@ class ConfirmationController @Inject()(
                                        citizenDetailsConnector: CitizenDetailsConnector
                                      )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
-  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData).async {
+  def onPageLoad: Action[AnyContent] = (identify andThen checkAlreadyClaimed andThen getData andThen requireData).async {
     implicit request =>
 
       citizenDetailsConnector.getAddress(request.nino).flatMap {

--- a/app/controllers/DisclaimerController.scala
+++ b/app/controllers/DisclaimerController.scala
@@ -31,12 +31,13 @@ class DisclaimerController @Inject()(
                                        override val messagesApi: MessagesApi,
                                        sessionRepository: SessionRepository,
                                        identify: IdentifierAction,
+                                       checkAlreadyClaimed: CheckAlreadyClaimedAction,
                                        getData: DataRetrievalAction,
                                        val controllerComponents: MessagesControllerComponents,
                                        view: DisclaimerView
                                      )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
-  def onPageLoad(): Action[AnyContent] = (identify andThen getData) {
+  def onPageLoad(): Action[AnyContent] = (identify andThen checkAlreadyClaimed andThen getData) {
     implicit request =>
 
       if (request.userAnswers.isEmpty) {

--- a/app/controllers/WhenDidYouFirstStartWorkingFromHomeController.scala
+++ b/app/controllers/WhenDidYouFirstStartWorkingFromHomeController.scala
@@ -35,6 +35,7 @@ class WhenDidYouFirstStartWorkingFromHomeController @Inject()(
                                         sessionRepository: SessionRepository,
                                         navigator: Navigator,
                                         identify: IdentifierAction,
+                                        checkAlreadyClaimed: CheckAlreadyClaimedAction,
                                         getData: DataRetrievalAction,
                                         requireData: DataRequiredAction,
                                         formProvider: WhenDidYouFirstStartWorkingFromHomeFormProvider,
@@ -44,7 +45,7 @@ class WhenDidYouFirstStartWorkingFromHomeController @Inject()(
 
   val form = formProvider()
 
-  def onPageLoad(): Action[AnyContent] = (identify andThen getData andThen requireData) {
+  def onPageLoad(): Action[AnyContent] = (identify andThen checkAlreadyClaimed andThen getData andThen requireData) {
     implicit request =>
 
       val preparedForm = request.userAnswers.get(WhenDidYouFirstStartWorkingFromHomePage) match {
@@ -55,7 +56,7 @@ class WhenDidYouFirstStartWorkingFromHomeController @Inject()(
       Ok(view(preparedForm))
   }
 
-  def onSubmit(): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+  def onSubmit(): Action[AnyContent] = (identify andThen checkAlreadyClaimed andThen getData andThen requireData).async {
     implicit request =>
 
       form.bindFromRequest().fold(

--- a/app/controllers/YourTaxReliefController.scala
+++ b/app/controllers/YourTaxReliefController.scala
@@ -29,13 +29,14 @@ import scala.concurrent.ExecutionContext
 class YourTaxReliefController @Inject()(
                                        override val messagesApi: MessagesApi,
                                        identify: IdentifierAction,
+                                       checkAlreadyClaimed: CheckAlreadyClaimedAction,
                                        getData: DataRetrievalAction,
                                        requireData: DataRequiredAction,
                                        val controllerComponents: MessagesControllerComponents,
                                        view: YourTaxReliefView
                                      )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
-  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) {
+  def onPageLoad: Action[AnyContent] = (identify andThen checkAlreadyClaimed andThen getData andThen requireData) {
     implicit request =>
       request.userAnswers.get(WhenDidYouFirstStartWorkingFromHomePage) match {
         case None =>

--- a/app/controllers/actions/CheckAlreadyClaimedAction.scala
+++ b/app/controllers/actions/CheckAlreadyClaimedAction.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import com.google.inject.Inject
+import config.FrontendAppConfig
+import connectors.TaiConnector
+import models.OtherExpense
+import models.requests.IdentifierRequest
+import play.api.mvc.Results.Redirect
+import play.api.mvc._
+import uk.gov.hmrc.play.HeaderCarrierConverter
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class CheckAlreadyClaimedActionImpl @Inject()(appConfig: FrontendAppConfig,
+                                          taiConnector: TaiConnector,
+                                          val parser: BodyParsers.Default)
+                                         (implicit val executionContext: ExecutionContext) extends CheckAlreadyClaimedAction {
+  override protected def filter[A](request: IdentifierRequest[A]): Future[Option[Result]] = {
+    implicit val hc = HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
+    val taxYear = 2020
+    taiConnector.getIabdData(request.nino, taxYear).map {
+      case otherExpenses: Seq[OtherExpense] if otherExpenses.exists(_.grossAmount != 0) => Some(Redirect(appConfig.p87DigitalFormUrl))
+      case _ => None
+    }
+  }
+}
+
+trait CheckAlreadyClaimedAction extends ActionFilter[IdentifierRequest]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -142,7 +142,7 @@ mongodb {
 urls {
   login           = "http://localhost:9949/auth-login-stub/gg-sign-in"
   loginContinue   = "http://localhost:9336/employee-working-from-home-expenses"
-  p87DigitalForm  = "http://localhost:9001/digital-forms/form/tax-relief-for-expenses-of-employment/draft/guide"
+  p87DigitalForm  = "http://localhost:9091/digital-forms/form/tax-relief-for-expenses-of-employment/draft/guide"
   personalDetails = "http://localhost:9232/personal-account/personal-details"
   ivUplift        = "http://localhost:9948/iv-stub/uplift"
   ivCompletion    = "http://localhost:9336/employee-working-from-home-expenses"

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -36,6 +36,8 @@ trait SpecBase extends PlaySpec with GuiceOneAppPerSuite with TryValues with Sca
 
   val userAnswersId = "id"
 
+  val p87RedirectUrl = "p87-redirect-url"
+
   def emptyUserAnswers = UserAnswers(userAnswersId, Json.obj())
 
   def injector: Injector = app.injector
@@ -53,7 +55,8 @@ trait SpecBase extends PlaySpec with GuiceOneAppPerSuite with TryValues with Sca
       .overrides(
         bind[DataRequiredAction].to[DataRequiredActionImpl],
         bind[IdentifierAction].to[FakeIdentifierAction],
-        bind[DataRetrievalAction].toInstance(new FakeDataRetrievalAction(userAnswers))
+        bind[DataRetrievalAction].toInstance(new FakeDataRetrievalAction(userAnswers)),
+        bind[CheckAlreadyClaimedAction].to[FakeCheckAlreadyClaimedAction]
       )
 
   lazy val fakeNino = "AB123456A"
@@ -84,7 +87,7 @@ trait SpecBase extends PlaySpec with GuiceOneAppPerSuite with TryValues with Sca
        |    "taxYear": 2019,
        |    "type": 59,
        |    "source": 26,
-       |    "grossAmount": ${grossAmount.getOrElse("null")},
+       |    "grossAmount": ${grossAmount.getOrElse(0)},
        |    "receiptDate": null,
        |    "captureDate": null,
        |    "typeDescription": "Other Expenses",

--- a/test/controllers/actions/CheckAlreadyClaimedActionSpec.scala
+++ b/test/controllers/actions/CheckAlreadyClaimedActionSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import base.SpecBase
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, get, urlEqualTo}
+import config.FrontendAppConfig
+import models.requests.IdentifierRequest
+import org.scalatest.concurrent.ScalaFutures
+import play.api.Application
+import play.api.http.Status.OK
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc.Results._
+import play.api.mvc.{AnyContent, Result}
+import play.api.test.Helpers._
+import utils.WireMockHelper
+
+import scala.concurrent.Future
+
+class CheckAlreadyClaimedActionSpec extends SpecBase with WireMockHelper with ScalaFutures {
+
+  private lazy val fakeIdentifier = "fake-identifier"
+
+  private def checkIdentifierRequest(identifierRequest: IdentifierRequest[AnyContent]): Future[Result] = {
+    identifierRequest match {
+      case IdentifierRequest(_, identifier, nino) if identifier == fakeIdentifier
+        && nino == fakeNino => Future.successful(Ok)
+      case _ => Future.successful(InternalServerError)
+    }
+  }
+
+  override implicit lazy val app: Application = new GuiceApplicationBuilder()
+    .overrides(
+      bind(classOf[CheckAlreadyClaimedAction]).to(classOf[CheckAlreadyClaimedActionImpl])
+    )
+    .configure(
+      conf = "microservice.services.tai.port" -> server.port,
+      "otherExpensesId" -> 59,
+      "urls.p87DigitalForm" -> p87RedirectUrl
+    ).build()
+
+  private lazy val appConfig: FrontendAppConfig = injector.instanceOf[FrontendAppConfig]
+  private lazy val checkAlreadyClaimedAction: CheckAlreadyClaimedAction = injector.instanceOf[CheckAlreadyClaimedAction]
+  private lazy val identifierRequest = IdentifierRequest[AnyContent](fakeRequest, fakeIdentifier, fakeNino)
+  private lazy val grossAmount = 312
+
+  "checkAlreadyClaimedAction" must {
+    "allow access for claimants that have not already claimed for expenses" in {
+      server.stubFor(
+        get(urlEqualTo(s"/tai/$fakeNino/tax-account/2020/expenses/employee-expenses/${appConfig.otherExpensesId}"))
+          .willReturn(
+            aResponse()
+              .withStatus(OK)
+              .withBody(validIabdJson(None).toString)
+          )
+      )
+
+      val result = checkAlreadyClaimedAction.invokeBlock(identifierRequest, checkIdentifierRequest)
+      status(result) mustBe OK
+    }
+
+    "redirect claimants that have already claimed for expenses to p87" in {
+      server.stubFor(
+        get(urlEqualTo(s"/tai/$fakeNino/tax-account/2020/expenses/employee-expenses/${appConfig.otherExpensesId}"))
+          .willReturn(
+            aResponse()
+              .withStatus(OK)
+              .withBody(validIabdJson(Some(grossAmount)).toString)
+          )
+      )
+
+      val result = checkAlreadyClaimedAction.invokeBlock(identifierRequest, checkIdentifierRequest)
+      status(result) mustBe SEE_OTHER
+
+      whenReady(result) {
+        res =>
+          res.header.headers(LOCATION) mustBe p87RedirectUrl
+      }
+    }
+  }
+
+
+}

--- a/test/controllers/actions/FakeCheckAlreadyClaimedAction.scala
+++ b/test/controllers/actions/FakeCheckAlreadyClaimedAction.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+import models.requests.IdentifierRequest
+import play.api.mvc._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class FakeCheckAlreadyClaimedAction extends CheckAlreadyClaimedAction {
+
+  override protected implicit val executionContext: ExecutionContext =
+    scala.concurrent.ExecutionContext.Implicits.global
+
+  override protected def filter[A](request: IdentifierRequest[A]): Future[Option[Result]] = Future.successful(None)
+}


### PR DESCRIPTION
# DL-4058 - Create a new ActionBuilder to check if a claim has already been submitted

Implemented an action that takes the user's NINO and asks TAI whether they've claimed for expenses already. If they have, they're redirected to the DFS p87 form. Otherwise, they can continue using the service.

## Valid NINOs:
* `EE200000A` for the happy journey (haven't claimed for expenses yet)
* `EE100000A` for the redirect to p87
