### PR TITLE
DL-4138 Adding ability to fetch users ETag

### DIFF
--- a/app/connectors/CitizenDetailsConnector.scala
+++ b/app/connectors/CitizenDetailsConnector.scala
@@ -21,14 +21,20 @@ import config.FrontendAppConfig
 import javax.inject.Singleton
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
+import utils.HttpResponseHelper
 
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class CitizenDetailsConnector @Inject()(appConfig: FrontendAppConfig, httpClient: HttpClient) {
+class CitizenDetailsConnector @Inject()(appConfig: FrontendAppConfig, httpClient: HttpClient) extends HttpResponseHelper {
 
   def getAddress(nino: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
     val designatoryDetailsUrl: String = s"${appConfig.citizenDetailsHost}/citizen-details/$nino/designatory-details"
     httpClient.GET[HttpResponse](designatoryDetailsUrl)
+  }
+
+  def getETag(nino: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
+    val eTagUrl: String = s"${appConfig.citizenDetailsHost}/citizen-details/$nino/etag"
+    httpClient.GET(eTagUrl)
   }
 }

--- a/app/utils/HttpResponseHelper.scala
+++ b/app/utils/HttpResponseHelper.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import play.api.libs.json.{JsNull, JsResult, Json, Reads}
+import uk.gov.hmrc.http.{ HttpReads, HttpResponse }
+
+trait HttpResponseHelper {
+
+  // scalastyle:off object.name
+  object & {
+    def unapply(response: HttpResponse): Option[(HttpResponse, HttpResponse)] =
+      Some((response, response))
+  }
+
+  object status {
+    def unapply(response: HttpResponse): Option[Int] = Some(response.status)
+  }
+
+  class JsonParsed[A] {
+    def unapply(response: HttpResponse)(implicit rds: Reads[A]): Option[JsResult[A]] = {
+      val json = Option(response.json) getOrElse JsNull
+      Some(Json.fromJson[A](json))
+    }
+  }
+
+  object JsonParsed {
+    def apply[A] = new JsonParsed[A]
+  }
+
+  implicit val httpReads: HttpReads[HttpResponse] =
+    new HttpReads[HttpResponse] {
+      override def read(method: String, url: String, response: HttpResponse): HttpResponse =
+        response
+    }
+}

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -77,6 +77,14 @@ trait SpecBase extends PlaySpec with GuiceOneAppPerSuite with TryValues with Sca
      """.stripMargin
   )
 
+  lazy val validETagJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "etag":"115"
+       |}
+     """.stripMargin
+  )
+
   lazy val invalidJson: JsValue = Json.parse("""{ "invalid" : "json" }""")
 
   def validIabdJson(grossAmount: Option[Int]): JsValue = Json.parse(

--- a/test/connectors/CitizenDetailsConnectorSpec.scala
+++ b/test/connectors/CitizenDetailsConnectorSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
-import play.api.http.Status.OK
+import play.api.http.Status._
 import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.http.HttpResponse
 import utils.WireMockHelper
@@ -61,6 +61,148 @@ class CitizenDetailsConnectorSpec extends SpecBase with MockitoSugar with WireMo
           res.body mustBe validAddressJson.toString
       }
 
+    }
+
+    "return a 400 on failure" in {
+      server.stubFor(
+        get(urlEqualTo(s"/citizen-details/$fakeNino/designatory-details"))
+          .willReturn(
+            aResponse()
+              .withStatus(BAD_REQUEST)
+              .withBody(validAddressJson.toString)
+          )
+      )
+
+      val result = citizenDetailsConnector.getAddress(fakeNino)
+
+      whenReady(result) {
+        res =>
+          res mustBe a[HttpResponse]
+          res.status mustBe 400
+          res.body mustBe validAddressJson.toString
+      }
+
+    }
+
+    "return a 404 on failure" in {
+      server.stubFor(
+        get(urlEqualTo(s"/citizen-details/$fakeNino/designatory-details"))
+          .willReturn(
+            aResponse()
+              .withStatus(NOT_FOUND)
+              .withBody(validAddressJson.toString)
+          )
+      )
+
+      val result = citizenDetailsConnector.getAddress(fakeNino)
+
+      whenReady(result) {
+        res =>
+          res mustBe a[HttpResponse]
+          res.status mustBe 404
+          res.body mustBe validAddressJson.toString
+      }
+
+    }
+
+    "return a 500 on failure" in {
+      server.stubFor(
+        get(urlEqualTo(s"/citizen-details/$fakeNino/designatory-details"))
+          .willReturn(
+            aResponse()
+              .withStatus(INTERNAL_SERVER_ERROR)
+              .withBody(validAddressJson.toString)
+          )
+      )
+
+      val result = citizenDetailsConnector.getAddress(fakeNino)
+
+      whenReady(result) {
+        res =>
+          res mustBe a[HttpResponse]
+          res.status mustBe 500
+          res.body mustBe validAddressJson.toString
+      }
+
+    }
+  }
+
+  "getETag" must {
+    "return an etag on success" in {
+      server.stubFor(
+        get(urlEqualTo(s"/citizen-details/$fakeNino/etag"))
+          .willReturn(
+            aResponse()
+              .withStatus(OK)
+              .withBody(validETagJson.toString)
+          )
+      )
+
+      val result = citizenDetailsConnector.getETag(fakeNino)
+
+      whenReady(result) {
+        res =>
+          res mustBe a[HttpResponse]
+          res.status mustBe 200
+          res.body mustBe validETagJson.toString
+      }
+    }
+
+    "return 500 on failure" in {
+      server.stubFor(
+        get(urlEqualTo(s"/citizen-details/$fakeNino/etag"))
+          .willReturn(
+            aResponse()
+              .withStatus(INTERNAL_SERVER_ERROR)
+          )
+      )
+
+      val result: Future[HttpResponse] = citizenDetailsConnector.getETag(fakeNino)
+
+      whenReady(result) {
+        res =>
+          res mustBe a[HttpResponse]
+          res.status mustBe 500
+          res.body mustBe ""
+      }
+    }
+
+    "return 401 on failure" in {
+      server.stubFor(
+        get(urlEqualTo(s"/citizen-details/$fakeNino/etag"))
+          .willReturn(
+            aResponse()
+              .withStatus(UNAUTHORIZED)
+          )
+      )
+
+      val result: Future[HttpResponse] = citizenDetailsConnector.getETag(fakeNino)
+
+      whenReady(result) {
+        res =>
+          res mustBe a[HttpResponse]
+          res.status mustBe 401
+          res.body mustBe ""
+      }
+    }
+
+    "return 404 on failure" in {
+      server.stubFor(
+        get(urlEqualTo(s"/citizen-details/$fakeNino/etag"))
+          .willReturn(
+            aResponse()
+              .withStatus(NOT_FOUND)
+          )
+      )
+
+      val result: Future[HttpResponse] = citizenDetailsConnector.getETag(fakeNino)
+
+      whenReady(result) {
+        res =>
+          res mustBe a[HttpResponse]
+          res.status mustBe 404
+          res.body mustBe ""
+      }
     }
   }
 


### PR DESCRIPTION
DL-4138

- Amended the **CitizenDetailsConnectorSpec** to add the ability to get a users ETag (via NINO).

- Added relevant unit tests for **CitizenDetailsConnectorSpec**


## Checklist

*@danny-waughman* (Replace with your name)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
