### PR TITLE
DL-4108 Dynamic content added

### DIFF
--- a/app/controllers/actions/ManualCorrespondenceIndicatorAction.scala
+++ b/app/controllers/actions/ManualCorrespondenceIndicatorAction.scala
@@ -41,8 +41,10 @@ class ManualCorrespondenceIndicatorActionImpl @Inject()(
           case OK =>
             None
           case LOCKED =>
+            Logger.info(s"[ManualCorrespondenceIndicatorAction][filter] - Locked status code")
             Some(Redirect(routes.ManualCorrespondenceIndicatorController.onPageLoad().url))
-          case _ =>
+          case statusCode =>
+            Logger.warn(s"[ManualCorrespondenceIndicatorAction][filter] - Unexpected status code: $statusCode ")
             Some(Redirect(routes.TechnicalDifficultiesController.onPageLoad().url))
         }
     }.recoverWith {

--- a/app/services/SubmissionService.scala
+++ b/app/services/SubmissionService.scala
@@ -17,7 +17,6 @@
 package services
 
 import java.time.LocalDate
-import java.time.temporal.ChronoUnit
 
 import config.FrontendAppConfig
 import connectors.{CitizenDetailsConnector, TaiConnector}
@@ -44,7 +43,6 @@ class SubmissionService @Inject()
   appConfig:                FrontendAppConfig
 ) {
 
-  val ONE_WEEK  = 1
   val ZERO      = 0
 
 
@@ -93,16 +91,6 @@ class SubmissionService @Inject()
       submittedDetails => Right(submittedDetails)
     } recover {
       case e => Left(e.getMessage)
-    }
-  }
-
-
-  def numberOfWeeks(startDate:LocalDate, endDate:LocalDate): Long = {
-    if (startDate.equals(endDate)) {
-      ONE_WEEK
-    } else {
-      val numberOfDays: Long = ChronoUnit.DAYS.between(startDate, endDate).abs
-      (((numberOfDays + 7 - 1) / 7) * 7) / 7
     }
   }
 

--- a/app/utils/TaxYearDates.scala
+++ b/app/utils/TaxYearDates.scala
@@ -17,6 +17,7 @@
 package utils
 
 import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 
 object TaxYearDates {
 
@@ -28,7 +29,36 @@ object TaxYearDates {
   val TAX_YEAR_2020_START_DATE: LocalDate = LocalDate.of(2020, 4, 6)
 
   val TAX_YEAR_2020_END_DATE: LocalDate = LocalDate.of(2021, 4, 5)
+
+  val ONE_WEEK  = 1
   // scalastyle:on magic.number
 
+
+  def numberOfWeeks(startDate:LocalDate, endDate:LocalDate): Long = {
+    if (startDate.equals(endDate)) {
+      ONE_WEEK
+    } else {
+      val numberOfDays: Long = ChronoUnit.DAYS.between(startDate, endDate).abs
+      (numberOfDays + 6) / 7
+    }
+  }
+
+  def isIn2019TaxYear(date: LocalDate) =
+    if (
+        (date.isEqual(TAX_YEAR_2019_START_DATE) || date.isAfter(TAX_YEAR_2019_START_DATE)) &&
+        (date.isEqual(TAX_YEAR_2019_END_DATE) || date.isBefore(TAX_YEAR_2019_END_DATE))) {
+      true
+    } else {
+      false
+    }
+
+  def isIn2020TaxYear(date: LocalDate) =
+    if (
+      (date.isEqual(TAX_YEAR_2020_START_DATE) || date.isAfter(TAX_YEAR_2020_START_DATE)) &&
+        (date.isEqual(TAX_YEAR_2020_END_DATE) || date.isBefore(TAX_YEAR_2020_END_DATE))) {
+      true
+    } else {
+      false
+    }
 }
 

--- a/app/views/YourTaxRelief2019And2020View.scala.html
+++ b/app/views/YourTaxRelief2019And2020View.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
 @import java.time.LocalDate
 
 @this(
@@ -25,7 +24,7 @@
         button:             GovukButton
 )
 
-@(startedWorkingFromHome: LocalDate)(implicit request: Request[_], messages: Messages)
+@(startedWorkingFromHome: LocalDate, numberOfWeeksIn2019: Long)(implicit request: Request[_], messages: Messages)
 
 @readableDate(date:LocalDate) = {@{date.getDayOfMonth} @{messages(s"month.${date.getMonthValue}")} @{date.getYear}}
 
@@ -34,6 +33,14 @@
     <b>@readableDate(startedWorkingFromHome)</b>
     <br>
     <a href=@routes.WhenDidYouFirstStartWorkingFromHomeController.onPageLoad()>@messages("yourTaxRelief.changeThisDate.href.text")</a>
+}
+
+@pluralOrSingularWeeks(weeks: Long) = @{
+    if (weeks == 1) {
+        messages("number.of.weeks.singular", weeks)
+    } else {
+        messages("number.of.weeks.plural", weeks)
+    }
 }
 
 @main_template(
@@ -51,8 +58,10 @@
         content = HtmlContent(insetHtml())
         ))
 
-    <p class="govuk-body">@messages("yourTaxRelief.paragraph.one")</p>
-    <p class="govuk-body">@messages("yourTaxRelief.paragraph.two")</p>
+    <p class="govuk-body">
+        @messages("yourTaxRelief.2019And2020.paragraph.one", pluralOrSingularWeeks(numberOfWeeksIn2019))
+    </p>
+    <p class="govuk-body">@messages("yourTaxRelief.2019And2020.paragraph.two")</p>
 
     <h2 class="govuk-heading-m">@messages("yourTaxRelief.submitYourClaim.heading")</h2>
 

--- a/app/views/YourTaxRelief2020OnlyView.scala.html
+++ b/app/views/YourTaxRelief2020OnlyView.scala.html
@@ -1,0 +1,64 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import java.time.LocalDate
+
+@this(
+        main_template:      MainTemplate,
+        formHelper:         FormWithCSRF,
+        backLink:           GovukBackLink,
+        govukInsetText:     GovukInsetText,
+        button:             GovukButton
+)
+
+@(startedWorkingFromHome: LocalDate)(implicit request: Request[_], messages: Messages)
+
+@readableDate(date:LocalDate) = {@{date.getDayOfMonth} @{messages(s"month.${date.getMonthValue}")} @{date.getYear}}
+
+@insetHtml() = {
+    @messages("yourTaxRelief.inset.text")
+    <b>@readableDate(startedWorkingFromHome)</b>
+    <br>
+    <a href=@routes.WhenDidYouFirstStartWorkingFromHomeController.onPageLoad()>@messages("yourTaxRelief.changeThisDate.href.text")</a>
+}
+
+@main_template(
+    title = messages("yourTaxRelief.title"),
+    beforeContentBlock = Some(backLink(BackLink(
+        href = routes.WhenDidYouFirstStartWorkingFromHomeController.onPageLoad().url,
+        content = Text(messages("site.back")),
+        attributes = Map("id" -> "back-link")
+    )))
+) {
+
+    <h1 class="govuk-heading-xl">@messages("yourTaxRelief.heading")</h1>
+
+    @govukInsetText(InsetText(
+        content = HtmlContent(insetHtml())
+        ))
+
+    <p class="govuk-body">@messages("yourTaxRelief.2020.paragraph.one")</p>
+    <p class="govuk-body">@messages("yourTaxRelief.2020.paragraph.two")</p>
+
+    <h2 class="govuk-heading-m">@messages("yourTaxRelief.submitYourClaim.heading")</h2>
+
+    <p class="govuk-body">@messages("yourTaxRelief.disclaimer")</p>
+
+    @formHelper(action = YourTaxReliefController.onSubmit(), 'autoComplete -> "off") {
+    @button(Button(content = Text(messages("yourTaxRelief.submit.button.text"))))
+    }
+
+}

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -11,6 +11,6 @@ month.10 = Hydref
 month.11 = Tachwedd
 month.12 = Rhagfyr
 
-yourTaxRelief.inset.text = You started working from home on {0}.
+yourTaxRelief.inset.text = You started working from home on
 
 site.getHelpWithThisPage = Help gyda''r dudalen hon

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -15,6 +15,9 @@ date.day = Day
 date.month = Month
 date.year = Year
 
+number.of.weeks.plural = {0} weeks
+number.of.weeks.singular = {0} week
+
 site.startAgain = Restart your expenses claim
 
 error.browser.title.prefix = Error:
@@ -97,8 +100,10 @@ yourTaxRelief.title = Check your claim
 yourTaxRelief.heading = Check your claim
 yourTaxRelief.inset.text = You started working from home on
 yourTaxRelief.changeThisDate.href.text = Change this date
-yourTaxRelief.paragraph.one = You will receive tax relief on your expenses for working from home for 2 weeks of the previous tax year (6 April 2019 to 5 April 2020). You will also receive tax relief for the whole of the current tax year (6 April 2020 to 5 April 2021), however long you worked or are working from home.
-yourTaxRelief.paragraph.two = At the end of this tax year, the tax relief will stop. If you are required to work from home after 5 April 2021, you will need to claim again.
+yourTaxRelief.2020.paragraph.one = You will receive tax relief on your expenses for working from home for the whole of the current tax year (6 April 2020 to 5 April 2021), however long you worked or are working from home.
+yourTaxRelief.2020.paragraph.two = At the end of this tax year, the tax relief will stop. If you are required to work from home after 5 April 2021, you will need to claim again.
+yourTaxRelief.2019And2020.paragraph.one = You will receive tax relief on your expenses for working from home for {0} of the previous tax year (6 April 2019 to 5 April 2020). You will also receive tax relief for the whole of the current tax year (6 April 2020 to 5 April 2021), however long you worked or are working from home.
+yourTaxRelief.2019And2020.paragraph.two = At the end of this tax year, the tax relief will stop. If you are required to work from home after 5 April 2021, you will need to claim again.
 yourTaxRelief.submitYourClaim.heading = Now submit your claim
 yourTaxRelief.disclaimer = By submitting you are confirming that, to the best of your knowledge, the details you are providing are correct.
 yourTaxRelief.submit.button.text = Confirm and submit

--- a/test/services/SubmissionServiceSpec.scala
+++ b/test/services/SubmissionServiceSpec.scala
@@ -61,36 +61,6 @@ class SubmissionServiceSpec extends SpecBase with MockitoSugar with BeforeAndAft
     Mockito.reset(mockCitizenDetailsConnector, mockTaiConnector, mockAuditConnector)
   }
 
-  "calculateWeeks" when {
-    "rounding up the days to the next whole week" should {
-      val tests = Seq(
-        (TAX_YEAR_2019_END_DATE.minus(1, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 1),
-        (TAX_YEAR_2019_END_DATE.minus(2, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 1),
-        (TAX_YEAR_2019_END_DATE.minus(3, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 1),
-        (TAX_YEAR_2019_END_DATE.minus(4, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 1),
-        (TAX_YEAR_2019_END_DATE.minus(5, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 1),
-        (TAX_YEAR_2019_END_DATE.minus(6, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 1),
-        (TAX_YEAR_2019_END_DATE.minus(7, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 1),
-        (TAX_YEAR_2019_END_DATE.minus(8, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 2),
-        (TAX_YEAR_2019_END_DATE.minus(9, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 2),
-        (TAX_YEAR_2019_END_DATE.minus(10, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 2),
-        (TAX_YEAR_2019_END_DATE.minus(11, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 2),
-        (TAX_YEAR_2019_END_DATE.minus(12, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 2),
-        (TAX_YEAR_2019_END_DATE.minus(13, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 2),
-        (TAX_YEAR_2019_END_DATE.minus(14, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 2),
-        (TAX_YEAR_2019_END_DATE.minus(15, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 3),
-        (TAX_YEAR_2020_START_DATE, TAX_YEAR_2020_END_DATE, 52),
-        (TAX_YEAR_2019_START_DATE, TAX_YEAR_2019_END_DATE, 53)
-      )
-
-      for ( (startDate, endDate, numOfWeeks) <- tests) {
-        s"calculate $numOfWeeks as the number of weeks between $startDate and $endDate" in new Setup {
-          serviceUnderTest.numberOfWeeks(startDate,endDate) shouldBe numOfWeeks
-        }
-      }
-    }
-  }
-
   "calculate2019FlatRate" should {
 
     "calculate the total rate as £4" when {

--- a/test/services/TaxYearDatesSpec.scala
+++ b/test/services/TaxYearDatesSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import java.time.temporal.ChronoUnit
+
+import base.SpecBase
+import org.scalatest.Matchers.convertToAnyShouldWrapper
+import org.scalatestplus.mockito.MockitoSugar
+import utils.TaxYearDates._
+
+// scalastyle:off magic.number
+class TaxYearDatesSpec extends SpecBase with MockitoSugar {
+  "calculateWeeks" when {
+    "rounding up the days to the next whole week" when {
+      val tests = Seq(
+        (TAX_YEAR_2019_END_DATE.minus(1, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 1),
+        (TAX_YEAR_2019_END_DATE.minus(2, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 1),
+        (TAX_YEAR_2019_END_DATE.minus(3, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 1),
+        (TAX_YEAR_2019_END_DATE.minus(4, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 1),
+        (TAX_YEAR_2019_END_DATE.minus(5, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 1),
+        (TAX_YEAR_2019_END_DATE.minus(6, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 1),
+        (TAX_YEAR_2019_END_DATE.minus(7, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 1),
+        (TAX_YEAR_2019_END_DATE.minus(8, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 2),
+        (TAX_YEAR_2019_END_DATE.minus(9, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 2),
+        (TAX_YEAR_2019_END_DATE.minus(10, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 2),
+        (TAX_YEAR_2019_END_DATE.minus(11, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 2),
+        (TAX_YEAR_2019_END_DATE.minus(12, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 2),
+        (TAX_YEAR_2019_END_DATE.minus(13, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 2),
+        (TAX_YEAR_2019_END_DATE.minus(14, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 2),
+        (TAX_YEAR_2019_END_DATE.minus(15, ChronoUnit.DAYS), TAX_YEAR_2019_END_DATE, 3),
+        (TAX_YEAR_2020_START_DATE, TAX_YEAR_2020_END_DATE, 52),
+        (TAX_YEAR_2019_START_DATE, TAX_YEAR_2019_END_DATE, 53)
+      )
+
+      for ( (startDate, endDate, numOfWeeks) <- tests) {
+        s"calculate $numOfWeeks as the number of weeks between $startDate and $endDate" in {
+          numberOfWeeks(startDate,endDate) shouldBe numOfWeeks
+        }
+      }
+    }
+  }
+}

--- a/test/views/YourTaxRelief2019And2020OnlyViewSpec.scala
+++ b/test/views/YourTaxRelief2019And2020OnlyViewSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import java.time.LocalDate
+
+import utils.TaxYearDates._
+import views.behaviours.ViewBehaviours
+import views.html.YourTaxRelief2019And2020View
+
+// scalastyle:off magic.number
+class YourTaxRelief2019And2020OnlyViewSpec extends ViewBehaviours {
+
+  val view = viewFor[YourTaxRelief2019And2020View](Some(emptyUserAnswers))
+
+  "YourTaxRelief2019And2020View" must {
+    val applyView = view.apply(TAX_YEAR_2019_START_DATE, 53)(fakeRequest, messages)
+
+    behave like normalPage(applyView, "yourTaxRelief")
+
+    behave like pageWithBackLink(applyView)
+
+    "must display the number of weeks on the page (plural)" in {
+      val workingFromHomeDate: LocalDate = TAX_YEAR_2019_START_DATE
+
+      val applyView = view.apply(workingFromHomeDate, 53)(fakeRequest, messages)
+
+      val doc = asDocument(applyView)
+      assertContainsText(doc, messages("yourTaxRelief.2019And2020.paragraph.one", "53 weeks"))
+    }
+
+    "must display the number of weeks on the page (singular)" in {
+      val applyView = view.apply(TAX_YEAR_2019_END_DATE, 1)(fakeRequest, messages)
+
+      val doc = asDocument(applyView)
+      assertContainsText(doc, messages("yourTaxRelief.2019And2020.paragraph.one", "1 week"))
+    }
+
+    "must display the working from home start date in a easy readable fashion" in {
+      val applyView = view.apply(TAX_YEAR_2019_START_DATE, 53)(fakeRequest, messages)
+
+      val doc = asDocument(applyView)
+      assertContainsText(doc, "6 April 2019")
+    }
+  }
+
+}

--- a/test/views/YourTaxRelief2020OnlyViewSpec.scala
+++ b/test/views/YourTaxRelief2020OnlyViewSpec.scala
@@ -16,22 +16,27 @@
 
 package views
 
-import java.time.LocalDate
+import utils.TaxYearDates._
 import views.behaviours.ViewBehaviours
-import views.html.YourTaxReliefView
+import views.html.YourTaxRelief2020OnlyView
 
-class YourTaxReliefViewSpec extends ViewBehaviours {
+// scalastyle:off magic.number
+class YourTaxRelief2020OnlyViewSpec extends ViewBehaviours {
 
-  val workingFromHomeDate = LocalDate.of(2019,4,6)
+  val view = viewFor[YourTaxRelief2020OnlyView](Some(emptyUserAnswers))
 
-  "YourTaxRelief view" must {
-
-    val view = viewFor[YourTaxReliefView](Some(emptyUserAnswers))
-
-    val applyView = view.apply(workingFromHomeDate)(fakeRequest, messages)
+  "YourTaxRelief2020OnlyView" must {
+    val applyView = view.apply(TAX_YEAR_2020_START_DATE)(fakeRequest, messages)
 
     behave like normalPage(applyView, "yourTaxRelief")
 
     behave like pageWithBackLink(applyView)
+
+    "must display the working from home start date in a easy readable fashion" in {
+      val doc = asDocument(applyView)
+      assertContainsText(doc, "6 April 2020")
+    }
   }
+
+
 }


### PR DESCRIPTION
# DL-4108 Dynamic content added

**Bug fix**

Adding back in functionality to display different content based on the working from home start date. When the start date is within the 2019-20 tax year, the page will calculate and display the number of weeks that you will receive tax relief for working from home in that tax year (rounded up to the nearest week)

## Checklist

*Reviewee* (@grahampaulcook )
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
