### PR TITLE
DL-4922 Changing feedback link on confirmation page

### DIFF
--- a/app/views/ConfirmationView.scala.html
+++ b/app/views/ConfirmationView.scala.html
@@ -29,7 +29,7 @@
 
 @(paperLessAvailable: Boolean, paperlessSignupUrl: Option[String], startedInTaxYear: Option[TaxYear])(implicit messages: Messages)
 
-@linkToFeedbackForm = {<a href="https://www.tax.service.gov.uk/feedback/employee-expenses-wfh">@messages("confirmation.linkToFeedbackForm.href.text")</a>}
+@linkToFeedbackForm = {<a href=@frontendAppConfig.feedbackSurvey>@messages("confirmation.linkToFeedbackForm.href.text")</a>}
 
 @main_template(title = messages("confirmation.title")) {
 


### PR DESCRIPTION
DL-4922

Changing feedback link on the confirmation page so the service only uses one feedback URL


## Checklist

*Danny Waughman* (Replace with your name)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
