### PR TITLE
DL-5986 Force SA enrolled users through claiming current year only

### DIFF
--- a/app/controllers/IndexController.scala
+++ b/app/controllers/IndexController.scala
@@ -19,7 +19,7 @@ package controllers
 import controllers.actions.{CheckAlreadyClaimedAction, DataRetrievalAction, IdentifierAction, ManualCorrespondenceIndicatorAction}
 import models.UserAnswers
 import navigation.Navigator
-import pages.ClaimedForTaxYear2020
+import pages.{ClaimedForTaxYear2020, HasSelfAssessmentEnrolment}
 import play.api.i18n.I18nSupport
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -47,8 +47,17 @@ class IndexController @Inject()(
       for {
         alreadyClaimed <- iabdService.alreadyClaimed(request.nino, YEAR_2020)
       } yield {
-        val answers = UserAnswers(request.internalId, Json.obj(ClaimedForTaxYear2020.toString -> alreadyClaimed.isDefined))
+
+        val answers = UserAnswers(
+          request.internalId,
+          Json.obj(
+            ClaimedForTaxYear2020.toString -> alreadyClaimed.isDefined,
+            HasSelfAssessmentEnrolment.toString -> request.saUtr.isDefined
+          )
+        )
+
         sessionRepository.set(answers)
+
         Redirect(navigator.nextPage(ClaimedForTaxYear2020, answers))
       }
     }

--- a/app/controllers/actions/DataRequiredAction.scala
+++ b/app/controllers/actions/DataRequiredAction.scala
@@ -37,7 +37,7 @@ class DataRequiredActionImpl @Inject()(implicit val executionContext: ExecutionC
       case Some(data) if data.get(SubmittedClaim).isDefined && !currentlyOnTheConfirmationPage =>
         Future.successful(Left(Redirect(routes.ConfirmationController.onPageLoad())))
       case Some(data) =>
-        Future.successful(Right(DataRequest(request.request, request.internalId, data, request.nino)))
+        Future.successful(Right(DataRequest(request.request, request.internalId, data, request.nino, request.saUtr)))
     }
   }
 }

--- a/app/controllers/actions/DataRetrievalAction.scala
+++ b/app/controllers/actions/DataRetrievalAction.scala
@@ -33,9 +33,9 @@ class DataRetrievalActionImpl @Inject()(
     
     sessionRepository.get(request.identifier).map {
       case None =>
-        OptionalDataRequest(request.request, request.identifier, None, request.nino)
+        OptionalDataRequest(request.request, request.identifier, None, request.nino, request.saUtr)
       case Some(userAnswers) =>
-        OptionalDataRequest(request.request, request.identifier, Some(userAnswers), request.nino)
+        OptionalDataRequest(request.request, request.identifier, Some(userAnswers), request.nino, request.saUtr)
     }
   }
 }

--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -65,12 +65,17 @@ final case class UserAnswers(
     }
   }
 
-  def is2021Only: Boolean =
-    (get(ClaimedForTaxYear2020), get(SelectTaxYearsToClaimForPage)) match {
-      case ( Some(true), _ ) => true
-      case ( _, Some(years) ) if years.size == 1 && years.contains(Option1) => true
-      case ( _, _ ) => false
+  def is2021Only: Boolean = {
+    get(HasSelfAssessmentEnrolment) match {
+      case Some(true) => true
+      case Some(false) =>
+        (get(ClaimedForTaxYear2020), get(SelectTaxYearsToClaimForPage)) match {
+          case ( Some(true), _ ) => true
+          case ( _, Some(years) ) if years.size == 1 && years.contains(Option1) => true
+          case ( _, _ ) => false
+        }
     }
+  }
 
   def is2019And2020Only: Boolean =
     (is2021Only, get(SelectTaxYearsToClaimForPage)) match {

--- a/app/models/requests/DataRequest.scala
+++ b/app/models/requests/DataRequest.scala
@@ -19,6 +19,16 @@ package models.requests
 import play.api.mvc.{Request, WrappedRequest}
 import models.UserAnswers
 
-case class OptionalDataRequest[A] (request: Request[A], internalId: String, userAnswers: Option[UserAnswers], nino: String) extends WrappedRequest[A](request)
+case class OptionalDataRequest[A] (
+                                    request: Request[A],
+                                    internalId: String,
+                                    userAnswers: Option[UserAnswers],
+                                    nino: String,
+                                    saUtr: Option[String]) extends WrappedRequest[A](request)
 
-case class DataRequest[A] (request: Request[A], internalId: String, userAnswers: UserAnswers, nino: String) extends WrappedRequest[A](request)
+case class DataRequest[A] (
+                            request: Request[A],
+                            internalId: String,
+                            userAnswers: UserAnswers,
+                            nino: String,
+                            saUtr: Option[String]) extends WrappedRequest[A](request)

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -52,10 +52,15 @@ class Navigator @Inject()() extends Logging {
   }
 
   def claimJourneyFlow(userAnswers: UserAnswers): Call = {
-    userAnswers.get(ClaimedForTaxYear2020) match {
-      case Some(claimedAlready) if claimedAlready   => routes.DisclaimerController.onPageLoad()
-      case Some(claimedAlready) if !claimedAlready  => routes.SelectTaxYearsToClaimForController.onPageLoad()
-      case None                                     => routes.IndexController.onPageLoad()
+    userAnswers.get(HasSelfAssessmentEnrolment) match {
+      case None         => routes.IndexController.onPageLoad()
+      case Some(true)   => routes.DisclaimerController.onPageLoad()
+      case Some(false)  =>
+        userAnswers.get(ClaimedForTaxYear2020) match {
+          case Some(claimedAlready) if claimedAlready   => routes.DisclaimerController.onPageLoad()
+          case Some(claimedAlready) if !claimedAlready  => routes.SelectTaxYearsToClaimForController.onPageLoad()
+          case None                                     => routes.IndexController.onPageLoad()
+        }
     }
   }
 

--- a/app/pages/HasSelfAssessmentEnrolment.scala
+++ b/app/pages/HasSelfAssessmentEnrolment.scala
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
-package models.requests
+package pages
 
-import play.api.mvc.{Request, WrappedRequest}
+import play.api.libs.json.JsPath
 
-case class IdentifierRequest[A] (request: Request[A], identifier: String, nino: String, saUtr: Option[String] = None) extends WrappedRequest[A](request)
+case object HasSelfAssessmentEnrolment extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "hasSelfAssessmentEnrolment"
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,10 +7,10 @@ object AppDependencies {
     "org.reactivemongo"   %% "play2-reactivemongo"            % "0.19.7-play28",
     "uk.gov.hmrc"         %% "logback-json-logger"            % "5.1.0",
     "uk.gov.hmrc"         %% "play-conditional-form-mapping"  % "1.9.0-play-28",
-    "uk.gov.hmrc"         %% "bootstrap-frontend-play-28"     % "5.3.0",
-    "uk.gov.hmrc"         %% "play-frontend-hmrc"             % "0.72.0-play-28",
+    "uk.gov.hmrc"         %% "bootstrap-frontend-play-28"     % "5.7.0",
+    "uk.gov.hmrc"         %% "play-frontend-hmrc"             % "0.83.0-play-28",
     "uk.gov.hmrc"         %% "play-partials"                  % "8.1.0-play-28",
-    "uk.gov.hmrc"         %% "tax-year"                       % "1.3.0",
+    "uk.gov.hmrc"         %% "tax-year"                       % "1.4.0",
     "com.digitaltangible" %% "play-guard"                     % "2.4.0"
   )
 

--- a/test/controllers/ConfirmationControllerSpec.scala
+++ b/test/controllers/ConfirmationControllerSpec.scala
@@ -17,7 +17,6 @@
 package controllers
 
 import java.time.LocalDate
-
 import base.SpecBase
 import connectors.PaperlessPreferenceConnector
 import models.paperless.{PaperlessStatus, PaperlessStatusResponse, Url}
@@ -32,7 +31,7 @@ import views.html.{Confirmation2019_2020View, Confirmation2019_2020_2021View, Co
 import PaperlessAuditConst._
 import models.SelectTaxYearsToClaimFor.{Option1, Option2}
 import models.UserAnswers
-import pages.{ClaimedForTaxYear2020, SelectTaxYearsToClaimForPage, WhenDidYouFirstStartWorkingFromHomePage}
+import pages.{ClaimedForTaxYear2020, HasSelfAssessmentEnrolment, SelectTaxYearsToClaimForPage, WhenDidYouFirstStartWorkingFromHomePage}
 import play.api.libs.json.Json
 import uk.gov.hmrc.time.TaxYear
 
@@ -110,6 +109,7 @@ class ConfirmationControllerSpec extends SpecBase with MockitoSugar {
     val application = applicationBuilder(userAnswers = Some(
       UserAnswers(userAnswersId, Json.obj(
         ClaimedForTaxYear2020.toString -> claimedForTaxYear2020,
+        HasSelfAssessmentEnrolment.toString -> false,
         SelectTaxYearsToClaimForPage.toString -> optionJsonList,
         WhenDidYouFirstStartWorkingFromHomePage.toString -> earliestWorkingFromHomeDate)))
     ).overrides(bind[PaperlessPreferenceConnector].toInstance(paperlessPreferenceConnector))

--- a/test/controllers/DisclaimerControllerSpec.scala
+++ b/test/controllers/DisclaimerControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import base.SpecBase
 import models.SelectTaxYearsToClaimFor.{Option1, Option2}
 import models.UserAnswers
-import pages.{ClaimedForTaxYear2020, SelectTaxYearsToClaimForPage}
+import pages.{ClaimedForTaxYear2020, HasSelfAssessmentEnrolment, SelectTaxYearsToClaimForPage}
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -32,21 +32,46 @@ class DisclaimerControllerSpec extends SpecBase {
     "return the 2021 content view" when {
       val tests = Seq(
         (
-          "already claimed expenses for 2020", UserAnswers(
+          "not SA enrolled and has already claimed expenses for 2020", UserAnswers(
             userAnswersId,
-            Json.obj(ClaimedForTaxYear2020.toString -> true)
+            Json.obj(
+              ClaimedForTaxYear2020.toString -> true,
+              HasSelfAssessmentEnrolment.toString -> false
+            )
           )
         ),
 
         (
-          "not already claimed but have chosen only to claim for 2021", UserAnswers(
+          "not SA enrolled and hasn't already claimed but have chosen only to claim for 2021", UserAnswers(
             userAnswersId,
             Json.obj(
               ClaimedForTaxYear2020.toString -> false,
+              HasSelfAssessmentEnrolment.toString -> false,
               SelectTaxYearsToClaimForPage.toString -> Json.arr(Option1.toString)
             )
           )
+        ),
+
+        (
+          "is SA enrolled and has already claimed expenses for 2020", UserAnswers(
+          userAnswersId,
+          Json.obj(
+            ClaimedForTaxYear2020.toString -> true,
+            HasSelfAssessmentEnrolment.toString -> true
+          )
         )
+        ),
+
+        (
+          "is SA enrolled and hasn't already claimed expenses for 2020", UserAnswers(
+          userAnswersId,
+          Json.obj(
+            ClaimedForTaxYear2020.toString -> false,
+            HasSelfAssessmentEnrolment.toString -> true
+          )
+        )
+        )
+
       )
       for((desc, userAnswer) <- tests) {
         s"$desc" in {
@@ -69,57 +94,59 @@ class DisclaimerControllerSpec extends SpecBase {
     }
 
     "return the 2019 & 2020 content view" when {
-      "not already claimed expenses for 2020 and tax years 2019 & 2020 have only been selected" in {
-        val userAnswer = UserAnswers(
-          userAnswersId,
-          Json.obj(
-            ClaimedForTaxYear2020.toString -> false,
-            SelectTaxYearsToClaimForPage.toString -> Json.arr(Option2.toString)
+        "not already claimed expenses for 2020 and tax years 2019 & 2020 have only been selected" in {
+          val userAnswer = UserAnswers(
+            userAnswersId,
+            Json.obj(
+              ClaimedForTaxYear2020.toString -> false,
+              HasSelfAssessmentEnrolment.toString -> false,
+              SelectTaxYearsToClaimForPage.toString -> Json.arr(Option2.toString)
+            )
           )
-        )
 
-        val application = applicationBuilder(userAnswers = Some(userAnswer)).build()
+          val application = applicationBuilder(userAnswers = Some(userAnswer)).build()
 
-        val view = application.injector.instanceOf[Disclaimer2019_2020View]
+          val view = application.injector.instanceOf[Disclaimer2019_2020View]
 
-        val request = FakeRequest(GET, routes.DisclaimerController.onPageLoad().url)
+          val request = FakeRequest(GET, routes.DisclaimerController.onPageLoad().url)
 
-        val result = route(application, request).value
+          val result = route(application, request).value
 
-        status(result) mustEqual OK
+          status(result) mustEqual OK
 
-        contentAsString(result) mustEqual
-          view()(request, messages).toString
+          contentAsString(result) mustEqual
+            view()(request, messages).toString
 
-        application.stop()
-      }
+          application.stop()
+        }
     }
 
     "return the 2019, 2020 & 2021 content view" when {
-      "not already claimed expenses for 2020 and all tax years have been chosen" in {
-        val userAnswer = UserAnswers(
-          userAnswersId,
-          Json.obj(
-            ClaimedForTaxYear2020.toString -> false,
-            SelectTaxYearsToClaimForPage.toString -> Json.arr(Option1.toString, Option2.toString)
+        "not already claimed expenses for 2020 and all tax years have been chosen" in {
+          val userAnswer = UserAnswers(
+            userAnswersId,
+            Json.obj(
+              ClaimedForTaxYear2020.toString -> false,
+              HasSelfAssessmentEnrolment.toString -> false,
+              SelectTaxYearsToClaimForPage.toString -> Json.arr(Option1.toString, Option2.toString)
+            )
           )
-        )
 
-        val application = applicationBuilder(userAnswers = Some(userAnswer)).build()
+          val application = applicationBuilder(userAnswers = Some(userAnswer)).build()
 
-        val view = application.injector.instanceOf[Disclaimer2019_2020_2021View]
+          val view = application.injector.instanceOf[Disclaimer2019_2020_2021View]
 
-        val request = FakeRequest(GET, routes.DisclaimerController.onPageLoad().url)
+          val request = FakeRequest(GET, routes.DisclaimerController.onPageLoad().url)
 
-        val result = route(application, request).value
+          val result = route(application, request).value
 
-        status(result) mustEqual OK
+          status(result) mustEqual OK
 
-        contentAsString(result) mustEqual
-          view()(request, messages).toString
+          contentAsString(result) mustEqual
+            view()(request, messages).toString
 
-        application.stop()
-      }
+          application.stop()
+        }
     }
 
     "redirect to select tax years page" when {
@@ -127,7 +154,8 @@ class DisclaimerControllerSpec extends SpecBase {
         val userAnswer = UserAnswers(
           userAnswersId,
           Json.obj(
-            ClaimedForTaxYear2020.toString -> false
+            ClaimedForTaxYear2020.toString -> false,
+            HasSelfAssessmentEnrolment.toString -> false
           )
         )
 

--- a/test/controllers/WhenDidYouFirstStartWorkingFromHomeControllerSpec.scala
+++ b/test/controllers/WhenDidYouFirstStartWorkingFromHomeControllerSpec.scala
@@ -23,7 +23,7 @@ import models.UserAnswers
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
-import pages.{ClaimedForTaxYear2020, SelectTaxYearsToClaimForPage, WhenDidYouFirstStartWorkingFromHomePage}
+import pages.{ClaimedForTaxYear2020, HasSelfAssessmentEnrolment, SelectTaxYearsToClaimForPage, WhenDidYouFirstStartWorkingFromHomePage}
 import play.api.inject.bind
 import play.api.libs.json.Json
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, Call}
@@ -31,8 +31,8 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import repositories.SessionRepository
 import views.html.{WhenDidYouFirstStartWorkingFromHome2019_2020View, WhenDidYouFirstStartWorkingFromHome2019_2020_2021View}
-import java.time.LocalDate
 
+import java.time.LocalDate
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.Future
@@ -72,6 +72,7 @@ class WhenDidYouFirstStartWorkingFromHomeControllerSpec extends SpecBase with Mo
         userAnswersId,
         Json.obj(
           ClaimedForTaxYear2020.toString -> false,
+          HasSelfAssessmentEnrolment.toString -> false,
           SelectTaxYearsToClaimForPage.toString -> Json.arr(Option2.toString)
         )
       )
@@ -132,6 +133,7 @@ class WhenDidYouFirstStartWorkingFromHomeControllerSpec extends SpecBase with Mo
       val answers = UserAnswers(userAnswersId,
         Json.obj(
           ClaimedForTaxYear2020.toString -> false,
+          HasSelfAssessmentEnrolment.toString -> false,
           SelectTaxYearsToClaimForPage.toString -> Json.arr(Option1.toString, Option2.toString)
         ))
 
@@ -198,6 +200,7 @@ class WhenDidYouFirstStartWorkingFromHomeControllerSpec extends SpecBase with Mo
         userAnswersId,
         Json.obj(
           ClaimedForTaxYear2020.toString -> false,
+          HasSelfAssessmentEnrolment.toString -> false,
           SelectTaxYearsToClaimForPage.toString -> Json.arr(Option1.toString, Option2.toString)
         )
       ).set(WhenDidYouFirstStartWorkingFromHomePage, validAnswer).success.value

--- a/test/controllers/YourTaxReliefControllerSpec.scala
+++ b/test/controllers/YourTaxReliefControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import base.SpecBase
 import models.SelectTaxYearsToClaimFor.{Option1, Option2}
 import models.UserAnswers
-import pages.{ClaimedForTaxYear2020, SelectTaxYearsToClaimForPage, WhenDidYouFirstStartWorkingFromHomePage}
+import pages.{ClaimedForTaxYear2020, HasSelfAssessmentEnrolment, SelectTaxYearsToClaimForPage, WhenDidYouFirstStartWorkingFromHomePage}
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -36,20 +36,44 @@ class YourTaxReliefControllerSpec extends SpecBase {
       "return the 2021 content view" when {
         val tests = Seq(
           (
-            "already claimed expenses for 2020", UserAnswers(
+            "not SA enrolled and has already claimed expenses for 2020", UserAnswers(
               userAnswersId,
-              Json.obj(ClaimedForTaxYear2020.toString -> true)
+              Json.obj(
+                ClaimedForTaxYear2020.toString -> true,
+                HasSelfAssessmentEnrolment.toString -> false
+              )
             )
           ),
 
           (
-            "not already claimed but have chosen only to claim for 2021", UserAnswers(
+            "not SA enrolled and hasn't already claimed but have chosen only to claim for 2021", UserAnswers(
               userAnswersId,
               Json.obj(
                 ClaimedForTaxYear2020.toString -> false,
+                HasSelfAssessmentEnrolment.toString -> false,
                 SelectTaxYearsToClaimForPage.toString -> Json.arr(Option1.toString)
               )
             )
+          ),
+
+          (
+            "is SA enrolled and has already claimed expenses for 2020", UserAnswers(
+            userAnswersId,
+            Json.obj(
+              ClaimedForTaxYear2020.toString -> true,
+              HasSelfAssessmentEnrolment.toString -> true
+            )
+          )
+          ),
+
+          (
+            "is SA enrolled and hasn't already claimed expenses for 2020", UserAnswers(
+            userAnswersId,
+            Json.obj(
+              ClaimedForTaxYear2020.toString -> false,
+              HasSelfAssessmentEnrolment.toString -> true
+            )
+          )
           )
         )
         for((desc, userAnswer) <- tests) {
@@ -78,6 +102,7 @@ class YourTaxReliefControllerSpec extends SpecBase {
             userAnswersId,
             Json.obj(
               ClaimedForTaxYear2020.toString -> false,
+              HasSelfAssessmentEnrolment.toString -> false,
               SelectTaxYearsToClaimForPage.toString -> Json.arr(Option2.toString),
               WhenDidYouFirstStartWorkingFromHomePage.toString -> earliestWorkingFromHomeDate
             )
@@ -106,6 +131,7 @@ class YourTaxReliefControllerSpec extends SpecBase {
             userAnswersId,
             Json.obj(
               ClaimedForTaxYear2020.toString -> false,
+              HasSelfAssessmentEnrolment.toString -> false,
               SelectTaxYearsToClaimForPage.toString -> Json.arr(Option1.toString, Option2.toString),
               WhenDidYouFirstStartWorkingFromHomePage.toString -> earliestWorkingFromHomeDate
             )
@@ -134,6 +160,7 @@ class YourTaxReliefControllerSpec extends SpecBase {
             userAnswersId,
             Json.obj(
               ClaimedForTaxYear2020.toString -> false,
+              HasSelfAssessmentEnrolment.toString -> false,
               SelectTaxYearsToClaimForPage.toString -> Json.arr(Option2.toString)
             )
           )
@@ -154,6 +181,7 @@ class YourTaxReliefControllerSpec extends SpecBase {
             userAnswersId,
             Json.obj(
               ClaimedForTaxYear2020.toString -> false,
+              HasSelfAssessmentEnrolment.toString -> false,
               SelectTaxYearsToClaimForPage.toString -> Json.arr(Option1.toString, Option2.toString)
             )
           )

--- a/test/controllers/actions/CheckAlreadyClaimedActionSpec.scala
+++ b/test/controllers/actions/CheckAlreadyClaimedActionSpec.scala
@@ -44,7 +44,7 @@ class CheckAlreadyClaimedActionSpec extends SpecBase with ScalaFutures with Befo
 
   private def checkIdentifierRequest(identifierRequest: IdentifierRequest[AnyContent]): Future[Result] = {
     identifierRequest match {
-      case IdentifierRequest(_, identifier, nino) if identifier == fakeIdentifier
+      case IdentifierRequest(_, identifier, nino, _) if identifier == fakeIdentifier
         && nino == fakeNino => Future.successful(Ok)
       case _ => Future.successful(InternalServerError)
     }

--- a/test/controllers/actions/DataRequiredActionSpec.scala
+++ b/test/controllers/actions/DataRequiredActionSpec.scala
@@ -40,7 +40,7 @@ class DataRequiredActionSpec extends SpecBase with MockitoSugar with ScalaFuture
   "DataRequiredAction" should {
     "redirect to the session expired page" when {
       "there are no userAnswers in the session" in {
-        val optionalDataRequest = OptionalDataRequest(FakeRequest("GET", "/"), "internalId", None, "NINO")
+        val optionalDataRequest = OptionalDataRequest(FakeRequest("GET", "/"), "internalId", None, "NINO", None)
         val futureResult = new FilterUnderTest().callRefine(optionalDataRequest)
 
         whenReady(futureResult) { result =>
@@ -60,7 +60,7 @@ class DataRequiredActionSpec extends SpecBase with MockitoSugar with ScalaFuture
           Json.obj(SubmittedClaim.toString -> true)
         )
 
-        val optionalDataRequest = OptionalDataRequest(fakeRequest, "internalId", Some(userAnswers), "NINO")
+        val optionalDataRequest = OptionalDataRequest(fakeRequest, "internalId", Some(userAnswers), "NINO", None)
         val futureResult = new FilterUnderTest().callRefine(optionalDataRequest)
 
         whenReady(futureResult) { result =>
@@ -80,7 +80,7 @@ class DataRequiredActionSpec extends SpecBase with MockitoSugar with ScalaFuture
           Json.obj(SubmittedClaim.toString -> true)
         )
 
-        val optionalDataRequest = OptionalDataRequest(fakeRequest, "internalId", Some(userAnswers), "NINO")
+        val optionalDataRequest = OptionalDataRequest(fakeRequest, "internalId", Some(userAnswers), "NINO", None)
         val futureResult = new FilterUnderTest().callRefine(optionalDataRequest)
 
         whenReady(futureResult) { result =>

--- a/test/controllers/actions/FakeDataRetrievalAction.scala
+++ b/test/controllers/actions/FakeDataRetrievalAction.scala
@@ -26,9 +26,9 @@ class FakeDataRetrievalAction(dataToReturn: Option[UserAnswers]) extends DataRet
   override protected def transform[A](request: IdentifierRequest[A]): Future[OptionalDataRequest[A]] =
     dataToReturn match {
       case None =>
-        Future(OptionalDataRequest(request.request, request.identifier, None, request.nino))
+        Future(OptionalDataRequest(request.request, request.identifier, None, request.nino, request.saUtr))
       case Some(userAnswers) =>
-        Future(OptionalDataRequest(request.request, request.identifier, Some(userAnswers), request.nino))
+        Future(OptionalDataRequest(request.request, request.identifier, Some(userAnswers), request.nino, request.saUtr))
     }
 
   override protected implicit val executionContext: ExecutionContext =

--- a/test/services/SubmissionServiceSpec.scala
+++ b/test/services/SubmissionServiceSpec.scala
@@ -131,7 +131,7 @@ class SubmissionServiceSpec extends SpecBase with MockitoSugar with BeforeAndAft
 
   "submit" when {
 
-    implicit val dataRequest: DataRequest[AnyContent] = DataRequest(fakeRequest, "internalId", UserAnswers("id"), testNino)
+    implicit val dataRequest: DataRequest[AnyContent] = DataRequest(fakeRequest, "internalId", UserAnswers("id"), testNino, None)
 
     val etag1 = ETag(100)
     val etag2 = ETag(101)


### PR DESCRIPTION
# DL-5986 Force SA enrolled users through claiming current year only

**New feature**

Alters the user journey for SA enrolled users so that they can only claim for the current tax year.

## Checklist

*Reviewee*
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer*
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
